### PR TITLE
Add trimsuffix to remove windows line endings

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -32,6 +32,7 @@ func main() {
 			fmt.Println(err)
 			return
 		}
+		input = strings.TrimSuffix(input, "\r\n")
 		input = strings.Trim(input[:len(input)-1], " ")
 		if input == ".exit" {
 			break


### PR DESCRIPTION
This will fix commands in Windows CMD and Powershell. 